### PR TITLE
Fix escaping of <i> tags

### DIFF
--- a/app/views/item.jeco
+++ b/app/views/item.jeco
@@ -1,3 +1,4 @@
 <div class="item">
-  <%= @name or "<i>No Name</i>" %>
+  <%= @name %>
+  <%- "<i>No Name</i>" unless @name %>                                          
 </div>


### PR DESCRIPTION
Noticed this bug after running through the tutorial.
